### PR TITLE
Added blueprint support for the engine

### DIFF
--- a/OpenGL Engine/OpenGL Engine.vcxproj
+++ b/OpenGL Engine/OpenGL Engine.vcxproj
@@ -19,6 +19,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="src\components\EntityBlueprint.h" />
     <ClInclude Include="src\components\preDefinedComponents\CMultiTexture.h" />
     <ClInclude Include="src\graphics\shader\DynamicShader.h" />
     <ClInclude Include="src\components\EntityGroups.h" />
@@ -49,6 +50,7 @@
     <ClInclude Include="src\graphics\shader\StaticShader.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="src\components\EntityBlueprint.cpp" />
     <ClCompile Include="src\components\preDefinedComponents\CMultiTexture.cpp" />
     <ClCompile Include="src\graphics\shader\DynamicShader.cpp" />
     <ClCompile Include="src\components\preDefinedComponents\CColor.cpp" />

--- a/OpenGL Engine/OpenGL Engine.vcxproj.filters
+++ b/OpenGL Engine/OpenGL Engine.vcxproj.filters
@@ -99,6 +99,9 @@
     <ClInclude Include="src\components\preDefinedComponents\CMultiTexture.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="src\components\EntityBlueprint.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\graphics\display\Display.cpp">
@@ -171,6 +174,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="src\components\preDefinedComponents\CMultiTexture.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\components\EntityBlueprint.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/OpenGL Engine/src/Engine.cpp
+++ b/OpenGL Engine/src/Engine.cpp
@@ -130,6 +130,16 @@ Entity& Engine::EntityFactory::createEntity()
 	return m_entityManager->addEntity();
 }
 
+Entity& Engine::EntityFactory::createEntity(EntityBlueprint& mBlueprint)
+{
+	return m_entityManager->addEntity(mBlueprint);
+}
+
+EntityBlueprint& Engine::EntityFactory::newBlueprint()
+{
+	return m_entityManager->addBlueprint();
+}
+
 //============================================================================================================================
 //LOADER
 //============================================================================================================================

--- a/OpenGL Engine/src/Engine.h
+++ b/OpenGL Engine/src/Engine.h
@@ -2,6 +2,10 @@
 #include <string>
 #include <glm\glm.hpp>
 #include "algorithm\Algorithm.h"
+#include "components\Component.h"
+#include "components\Entity.h"
+#include "components\EntityBlueprint.h"
+#include "components\EntityGroups.h"
 #include "components\PreDefinedComponents.h"
 #include "input\InputKeys.h"
 
@@ -42,6 +46,8 @@ public:
 	{
 	public:
 		static Entity& createEntity();
+		static Entity& createEntity(EntityBlueprint& mBlueprint);
+		static EntityBlueprint& newBlueprint();
 	};
 
 	class Loader

--- a/OpenGL Engine/src/components/Component.cpp
+++ b/OpenGL Engine/src/components/Component.cpp
@@ -1,1 +1,7 @@
 #include "Component.h"
+
+ComponentID getUniqueComponentID() noexcept
+{
+	static ComponentID lastID{ 0u };
+	return lastID++;
+}

--- a/OpenGL Engine/src/components/Component.h
+++ b/OpenGL Engine/src/components/Component.h
@@ -1,4 +1,6 @@
 #pragma once
+#include <type_traits>
+
 class Entity;
 struct Component
 {
@@ -9,5 +11,18 @@ struct Component
 	virtual void draw() {}
 	virtual void handleMessage(const char* message) {}
 
+	//Required for blueprints
+	virtual Component* clone() { return new Component(*this); }
+
 	virtual ~Component() {}
 };
+
+using ComponentID = size_t;
+ComponentID getUniqueComponentID() noexcept;
+template<typename T>
+ComponentID getComponentTypeID() noexcept
+{
+	static_assert(std::is_base_of<Component, T>::value, "T must inherit from Component");
+	static ComponentID typeID{ getUniqueComponentID() };
+	return typeID;
+}

--- a/OpenGL Engine/src/components/Entity.cpp
+++ b/OpenGL Engine/src/components/Entity.cpp
@@ -8,7 +8,6 @@ void Entity::init()
 		c->init();
 	}
 }
-
 void Entity::update(float frameTime)
 {
 	for (auto& c : m_components)
@@ -16,7 +15,6 @@ void Entity::update(float frameTime)
 		c->update(frameTime);
 	}
 }
-
 void Entity::draw()
 {
 	for (auto& c : m_components)
@@ -24,7 +22,6 @@ void Entity::draw()
 		c->draw();
 	}
 }
-
 void Entity::handleMessage(const char * message)
 {
 	for (auto& c : m_components)
@@ -37,7 +34,6 @@ bool Entity::isAlive() const
 {
 	return m_alive;
 }
-
 void Entity::destroy()
 {
 	m_alive = false;
@@ -47,12 +43,10 @@ bool Entity::hasGroup(Group mGroup) const noexcept
 {
 	return m_groupBitset[mGroup];
 }
-
 void Entity::delGroup(Group mGroup) noexcept
 {
 	m_groupBitset[mGroup] = false;
 }
-
 void Entity::addGroup(Group mGroup) noexcept
 {
 	m_groupBitset[mGroup] = true;
@@ -62,7 +56,28 @@ void Entity::addGroup(Group mGroup) noexcept
 Entity::Entity(EntityManager& mManager)
 	: m_manager(mManager)
 {}
+Entity::Entity(EntityManager& mManager, EntityBlueprint& mBlueprint)
+	: m_manager(mManager)
+{
+	m_componentBitset = mBlueprint.m_componentBitset;
 
+	for (unsigned int i = 0; i < maxComponents; i++)
+	{
+		if (mBlueprint.m_componentArray[i] != nullptr)
+		{
+			if (m_componentArray[i] != nullptr)
+			{
+				delete m_componentArray[i];
+			}			
+			Component* comp = mBlueprint.m_components[i]->clone();
+			comp->entity = this;
+			comp->init();
+			std::unique_ptr<Component> uPtr{ comp };
+			m_components.emplace_back(std::move(uPtr));
+			m_componentArray[i] = comp;
+		}
+	}
+}
 Entity::~Entity()
 {
 	m_components.clear();

--- a/OpenGL Engine/src/components/Entity.h
+++ b/OpenGL Engine/src/components/Entity.h
@@ -7,14 +7,12 @@
 #include "Component.h"
 #include "EntityGroups.h"
 
-#include <iostream>
+static const size_t maxComponents = 32;
+static const size_t maxGroups = 32;
+using Group = size_t;
 
 class EntityManager;
 class EntityBlueprint;
-
-constexpr size_t maxComponents{ 32 };
-constexpr size_t maxGroups{ 32 };
-using Group = size_t;
 class Entity
 {
 public:
@@ -65,21 +63,8 @@ public:
 	void delGroup(Group mGroup) noexcept;
 
 	Entity(EntityManager& mManager);
+	Entity(EntityManager& mManager, EntityBlueprint& mBlueprint);
 	~Entity();
-private:
-	using ComponentID = size_t;
-	static inline ComponentID getUniqueComponentID() noexcept
-	{
-		static ComponentID lastID{ 0u };
-		return lastID++;
-	}
-	template<typename T>
-	static inline ComponentID getComponentTypeID() noexcept
-	{
-		static_assert(std::is_base_of<Component, T>::value, "T must inherit from Component");
-		static ComponentID typeID{ getUniqueComponentID() };
-		return typeID;
-	}	
 private:
 	EntityManager& m_manager;
 
@@ -93,5 +78,7 @@ private:
 
 	using GroupBitset = std::bitset<maxGroups>;
 	GroupBitset m_groupBitset;
+
+	friend EntityBlueprint;
 };
 

--- a/OpenGL Engine/src/components/EntityBlueprint.cpp
+++ b/OpenGL Engine/src/components/EntityBlueprint.cpp
@@ -1,0 +1,17 @@
+#include "EntityBlueprint.h"
+#include "EntityManager.h"
+#include "Entity.h"
+
+EntityBlueprint::EntityBlueprint(EntityManager& mManager)
+	: m_manager(mManager)
+{
+}
+EntityBlueprint::~EntityBlueprint()
+{
+	for (unsigned int i = 0; i < m_components.size(); i++)
+	{
+		delete m_components[i];
+	}
+
+	m_components.clear();
+}

--- a/OpenGL Engine/src/components/EntityBlueprint.h
+++ b/OpenGL Engine/src/components/EntityBlueprint.h
@@ -1,0 +1,53 @@
+#pragma once
+#include <vector>
+#include <array>
+#include <memory>
+#include <bitset>
+#include "Component.h"
+#include "Entity.h"
+
+class EntityManager;
+class EntityBlueprint
+{
+public:
+	EntityBlueprint(EntityManager& mManager);
+	~EntityBlueprint();
+
+	template<typename T, typename... TArgs>
+	T& addComponent(TArgs&&... mArgs)
+	{
+		if (hasComponent<T>())
+		{
+			return getComponent<T>();
+		}
+		T* c(new T(std::forward <TArgs>(mArgs)...));
+		m_components.emplace_back(c);
+		m_componentArray[getComponentTypeID<T>()] = c;
+		m_componentBitset[getComponentTypeID<T>()] = true;
+		return *c;
+	}
+
+	template<typename T>
+	bool hasComponent() const
+	{
+		return m_componentBitset[getComponentTypeID<T>()];
+	}
+	template<typename T>
+	T& getComponent() const
+	{
+		assert(hasComponent<T>());
+		auto ptr(m_componentArray[getComponentTypeID<T>()]);
+		return *static_cast<T*>(ptr);
+	}
+private:
+	EntityManager& m_manager;
+
+	std::vector<Component*> m_components;
+
+	using ComponentBitset = std::bitset<maxComponents>;
+	using ComponentArray = std::array<Component*, maxComponents>;
+	ComponentArray m_componentArray;
+	ComponentBitset m_componentBitset;
+
+	friend Entity;
+};

--- a/OpenGL Engine/src/components/EntityManager.cpp
+++ b/OpenGL Engine/src/components/EntityManager.cpp
@@ -1,6 +1,7 @@
 #include "EntityManager.h"
 #include <algorithm>
 #include "..\data manager\BatchManager.h"
+#include "EntityBlueprint.h"
 
 void EntityManager::refresh()
 {
@@ -56,6 +57,22 @@ Entity& EntityManager::addEntity()
 	return *e;
 }
 
+Entity & EntityManager::addEntity(EntityBlueprint& mBlueprint)
+{
+	Entity* e(new Entity(*this, mBlueprint));
+	std::unique_ptr<Entity> uPtr{ e };
+	m_entities.emplace_back(std::move(uPtr));
+	return *e;
+}
+
+EntityBlueprint& EntityManager::addBlueprint()
+{
+	EntityBlueprint* e(new EntityBlueprint(*this));
+	std::unique_ptr<EntityBlueprint> uPtr{ e };
+	m_blueprints.emplace_back(std::move(uPtr));
+	return *e;
+}
+
 void EntityManager::addToGroup(Entity * mEntity, Group mGroup)
 {
 	m_groupedEntities[mGroup].emplace_back(mEntity);
@@ -72,4 +89,5 @@ EntityManager::EntityManager(BatchManager* pManager)
 EntityManager::~EntityManager()
 {
 	m_entities.clear();
+	m_blueprints.clear();
 }

--- a/OpenGL Engine/src/components/EntityManager.h
+++ b/OpenGL Engine/src/components/EntityManager.h
@@ -1,5 +1,10 @@
 #pragma once
+#include <vector>
+#include <memory>
+#include <array>
+
 #include "Entity.h"
+#include "EntityBlueprint.h"
 
 class BatchManager;
 class EntityManager
@@ -9,6 +14,8 @@ public:
 	void update(float frameTime);
 	void draw();
 	Entity& addEntity();
+	Entity& addEntity(EntityBlueprint& mBlueprint);
+	EntityBlueprint& addBlueprint();
 
 	void addToGroup(Entity* mEntity, Group mGroup);
 	std::vector<Entity*>& getEntitiesByGroup(Group mGroup);
@@ -17,6 +24,7 @@ public:
 	~EntityManager();
 private:
 	std::vector<std::unique_ptr<Entity>> m_entities;
+	std::vector<std::unique_ptr<EntityBlueprint>> m_blueprints;
 	std::array<std::vector<Entity*>, maxGroups> m_groupedEntities;
 	BatchManager* m_bManager;
 };

--- a/OpenGL Engine/src/components/PreDefinedComponents.h
+++ b/OpenGL Engine/src/components/PreDefinedComponents.h
@@ -1,11 +1,4 @@
 #pragma once
-//==================================================================================================================================
-//ALL THE NEEDED HEADERS SO YOU FOR THE COMPONENT SYSTEM
-//==================================================================================================================================
-#include "Component.h"		//Base class that all components derive from
-#include "Entity.h"			//Class that uses these components
-#include "EntityGroups.h"	//Header containing all predefined entity groups
-
 #include "preDefinedComponents\CPosition.h"			//Position component
 #include "preDefinedComponents\CColor.h"			//Color component
 

--- a/OpenGL Engine/src/components/preDefinedComponents/CColor.h
+++ b/OpenGL Engine/src/components/preDefinedComponents/CColor.h
@@ -9,4 +9,6 @@ struct CColor : Component
 
 	CColor() = default;
 	CColor(const glm::vec3& mColor) : value{ mColor } {}
+
+	virtual CColor* clone() { return new CColor(*this); }
 };

--- a/OpenGL Engine/src/components/preDefinedComponents/CLightEmiter.h
+++ b/OpenGL Engine/src/components/preDefinedComponents/CLightEmiter.h
@@ -11,4 +11,6 @@ struct CLightEmiter : Component
 	CPosition* cPosition;
 	CColor* cColor;
 	CLightEmiter() {};
+
+	virtual CLightEmiter* clone() { return new CLightEmiter(*this); }
 };

--- a/OpenGL Engine/src/components/preDefinedComponents/CMaterial.h
+++ b/OpenGL Engine/src/components/preDefinedComponents/CMaterial.h
@@ -27,6 +27,8 @@ struct CMaterial : Component
 	{
 		return !(*this == mat);
 	}
+
+	virtual CMaterial* clone() { return new CMaterial(*this); }
 private:
 	unsigned int m_textureID;
 	friend BatchManager;

--- a/OpenGL Engine/src/components/preDefinedComponents/CMesh.h
+++ b/OpenGL Engine/src/components/preDefinedComponents/CMesh.h
@@ -25,6 +25,8 @@ struct CMesh : Component
 			return false;
 		}
 	}
+
+	virtual CMesh* clone() { return new CMesh(*this); }
 private:
 	unsigned int m_vaoID;
 	friend BatchManager;

--- a/OpenGL Engine/src/components/preDefinedComponents/CMultiTexture.h
+++ b/OpenGL Engine/src/components/preDefinedComponents/CMultiTexture.h
@@ -14,5 +14,8 @@ struct CMultiTexture : Component
 
 	CMultiTexture();
 	~CMultiTexture();
+
+
+	virtual CMultiTexture* clone() { return new CMultiTexture(*this); }
 };
 

--- a/OpenGL Engine/src/components/preDefinedComponents/CPosition.h
+++ b/OpenGL Engine/src/components/preDefinedComponents/CPosition.h
@@ -11,4 +11,6 @@ struct CPosition : Component
 
 	CPosition() = default;
 	CPosition(const glm::vec3& mPosition);
+
+	virtual CPosition* clone() { return new CPosition(*this); }
 };

--- a/OpenGL Engine/src/components/preDefinedComponents/CRenderer.h
+++ b/OpenGL Engine/src/components/preDefinedComponents/CRenderer.h
@@ -14,4 +14,6 @@ struct CRenderer : Component
 	bool multiTexture;
 
 	CRenderer() : tileCount(1), transparent(false), fakeLighting(false), multiTexture(false) {}
+
+	virtual CRenderer* clone() { return new CRenderer(*this); }
 };

--- a/OpenGL Engine/src/components/preDefinedComponents/CTransformation.h
+++ b/OpenGL Engine/src/components/preDefinedComponents/CTransformation.h
@@ -16,4 +16,6 @@ struct CTransformation : Component
 	float scale;
 
 	CTransformation(float mXRotation, float mYRotation, float mZRotation, float mScale);
+
+	virtual CTransformation* clone() { return new CTransformation(*this); }
 };

--- a/TestProject/main.cpp
+++ b/TestProject/main.cpp
@@ -6,24 +6,21 @@ int main()
 {
 	Engine::initialize(1280, 720, "TestWindow");
 
-	Entity& testEntity1(Engine::EntityFactory::createEntity());
-	testEntity1.addComponent<CPosition>(glm::vec3(0.0f, 0.0f, -20.0f));
-	testEntity1.addComponent<CTransformation>(0,0,0,1);
-	testEntity1.getComponent<CTransformation>().rotationX = 90;
-	testEntity1.addComponent<CMesh>(Engine::Loader::loadMesh("E:/Test files/nfw/stall.obj"));
-	testEntity1.addComponent<CMaterial>(Engine::Loader::loadMaterial("E:/Test files/nfw/stallTexture.png"), 10, 1);
+	EntityBlueprint& stallBlueprint(Engine::EntityFactory::newBlueprint());
+	stallBlueprint.addComponent<CPosition>(glm::vec3(0.0f, 0.0f, 0.0f));
+	stallBlueprint.addComponent<CTransformation>(0, 0, 0, 1);
+	stallBlueprint.addComponent<CMesh>(Engine::Loader::loadMesh("E:/Test files/nfw/stall.obj"));
+	stallBlueprint.addComponent<CMaterial>(Engine::Loader::loadMaterial("E:/Test files/nfw/stallTexture.png"), 10, 1);
 
-	Entity& testEntity2(Engine::EntityFactory::createEntity());
-	testEntity2.addComponent<CPosition>(glm::vec3(10.0f, 0.0f, -20.0f));
-	testEntity2.addComponent<CTransformation>(0, 0, 0, 1);
-	testEntity2.addComponent<CMesh>(Engine::Loader::loadMesh("E:/Test files/nfw/stall.obj"));
-	testEntity2.addComponent<CMaterial>(Engine::Loader::loadMaterial("E:/Test files/nfw/stallTexture.png"), 10, 1);
+	Entity& stallEntity1(Engine::EntityFactory::createEntity(stallBlueprint));
+	stallEntity1.getComponent<CPosition>().value = glm::vec3(0.0f, 0.0f, -20.0f);
+	stallEntity1.getComponent<CTransformation>().rotationX = 90;
 
-	Entity& testEntity3(Engine::EntityFactory::createEntity());
-	testEntity3.addComponent<CPosition>(glm::vec3(20.0f, 10.0f, -30.0f));
-	testEntity3.addComponent<CTransformation>(0, 0, 0, 1);
-	testEntity3.addComponent<CMesh>(Engine::Loader::loadMesh("E:/Test files/nfw/stall.obj"));
-	testEntity3.addComponent<CMaterial>(Engine::Loader::loadMaterial("E:/Test files/nfw/stallTexture.png"), 10, 1);
+	Entity& stallEntity2(Engine::EntityFactory::createEntity(stallBlueprint));
+	stallEntity2.getComponent<CPosition>().value = glm::vec3(10.0f, 0.0f, -20.0f);
+
+	Entity& stallEntity3(Engine::EntityFactory::createEntity(stallBlueprint));
+	stallEntity3.getComponent<CPosition>().value = glm::vec3(20.0f, 10.0f, -30.0f);
 
 	Entity& testTerrain1(Engine::EntityFactory::createEntity());
 	testTerrain1.addComponent<CPosition>(glm::vec3(0,0,0));


### PR DESCRIPTION
The new blueprints allow for a creation of an entity blueprint that can be reused by other entities to eliminate repeating code such as same mesh and material component addition